### PR TITLE
Fix method_missing for ActiveCampaign module

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,4 +31,3 @@ Metrics/LineLength:
 
 Style/IfUnlessModifier:
   Enabled: false
-  MaxLineLength: 80

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,10 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*_spec.rb'
 
+Metrics/MethodLength:
+  CountComments: false  # count full line comments?
+  Max: 12
+
 Metrics/ParameterLists:
   Enabled: true
   Max: 5

--- a/lib/active_campaign.rb
+++ b/lib/active_campaign.rb
@@ -34,8 +34,10 @@ module ActiveCampaign
 
   private
 
-  def method_missing(method_name, *args, &block)
-    return super unless client.respond_to?(method_name)
-    client.send(method_name, *args, &block)
+  class << self
+    def method_missing(method_name, *args, &block)
+      return super unless client.respond_to?(method_name)
+      client.send(method_name, *args, &block)
+    end
   end
 end

--- a/lib/active_campaign.rb
+++ b/lib/active_campaign.rb
@@ -32,12 +32,15 @@ module ActiveCampaign
     @config = Configuration.new
   end
 
-  private
-
   class << self
+    # rubocop:disable Style/MissingRespondToMissing
     def method_missing(method_name, *args, &block)
-      return super unless client.respond_to?(method_name)
-      client.send(method_name, *args, &block)
+      if client.respond_to?(method_name)
+        client.send(method_name, *args, &block)
+      else
+        super
+      end
     end
+    # rubocop:enable Style/MissingRespondToMissing
   end
 end

--- a/lib/active_campaign/client.rb
+++ b/lib/active_campaign/client.rb
@@ -58,10 +58,10 @@ module ActiveCampaign
 
     def ==(other)
       other.is_a?(ActiveCampaign::Client) &&
-        self.hash == other.hash
+        hash == other.hash
     end
 
-    alias_method :eql?, :==
+    alias eql? ==
 
     private
 

--- a/lib/active_campaign/configuration.rb
+++ b/lib/active_campaign/configuration.rb
@@ -21,7 +21,7 @@ module ActiveCampaign
       @debug = false
     end
 
-    def to_h # rubocop:disable MethodLength
+    def to_h
       {
         api_key: api_key,
         api_endpoint: api_endpoint,
@@ -54,8 +54,7 @@ module ActiveCampaign
         mash == other.mash &&
         debug == other.debug
     end
-    alias_method :eql?, :==
-
+    alias eql? ==
 
     def hash
       [

--- a/lib/active_campaign/core_ext.rb
+++ b/lib/active_campaign/core_ext.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class Hash
+  # unless respo?(:to_query)
   def to_query(namespace = nil)
     collect do |key, value|
       unless (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
         value.to_query(namespace ? "#{namespace}[#{key}]" : key)
       end
     end.compact.sort! * '&'
-  end # unless respo?(:to_query)
+  end
 end
 
 class Array
@@ -15,6 +16,7 @@ class Array
     collect(&:to_param).join '/'
   end
 
+  # unless respo?(:to_query)
   def to_query(key)
     prefix = "#{key}[]"
 
@@ -23,13 +25,14 @@ class Array
     else
       collect { |value| value.to_query(prefix) }.join '&'
     end
-  end # unless defined?(:to_query)
+  end
 end
 
 class Object
+  # unless respo?(:to_query)
   def to_query(key)
     "#{CGI.escape(key.to_param)}=#{CGI.escape(to_param.to_s)}"
-  end # unless defined?(:to_query)
+  end
 
   def to_param
     to_s

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ RSpec.configure do |config|
   end
 end
 
-def initialize_new_client # rubocop:disable MethodLength
+def initialize_new_client
   before do
     @client = ActiveCampaign::Client.new(
       api_endpoint: TEST_API_ENDPOINT,


### PR DESCRIPTION
Fixes #16 by defining ``method_missing`` as a class method, so it's called when running methods on the module directly, such as ``::ActiveCampaign.list_list(ids: "all")``.