### PR TITLE
Update TLS version to 1.2

### DIFF
--- a/lib/active_campaign/client.rb
+++ b/lib/active_campaign/client.rb
@@ -88,7 +88,7 @@ module ActiveCampaign
         body: body(method, api_method, options)
       )
       req.auth.ssl.verify_mode = :none
-      req.auth.ssl.ssl_version = :TLSv1
+      req.auth.ssl.ssl_version = :TLSv1_2
       req
     end
 


### PR DESCRIPTION
ActiveCampaign recently reached out mentioning they'll be [deprecating TLS 1.0 & 1.1](https://help.activecampaign.com/hc/en-us/articles/360003999019-tls-1-0).

From their email: "_You’ll need to upgrade your TLS settings to TLS 1.2 or higher by May 2. If you do not upgrade your TLS settings by this date, your API connection will no longer function properly._"

This PR updates the code to use `:TLSv1_2`.