### PR TITLE
Remove comma from global config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ client = ::ActiveCampaign::Client.new(
 
 # or configure globally for all clients
 ::ActiveCampaign.configure do |config|
-  config.api_url = 'YOUR-ENDPOINT', # e.g. 'https://youraccount.api-us1.com/api/3'
+  config.api_url = 'YOUR-ENDPOINT' # e.g. 'https://youraccount.api-us1.com/api/3'
   config.api_token = 'YOUR-API-KEY' # e.g. 'a4e60a1ba200595d5cc37ede5732545184165e'
 end
 


### PR DESCRIPTION
With the comma, it gives me the following error.

`api_url (["https://vuescreencasts.api-us1.com", "my_key"]) needs to be a String or URI (ArgumentError)`

Without the comma, it works.