### PR TITLE
Add `**params` for all collection endpoints

### DIFF
--- a/lib/active_campaign/api/account_contacts.rb
+++ b/lib/active_campaign/api/account_contacts.rb
@@ -37,11 +37,18 @@ module ActiveCampaign
       # Get a list of account contacts
       #
       # @param [String] search Filter account contacts that match the given value in the account attributes
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Array<Hash>]
       #
-      def show_account_contacts(search = nil)
-        get('accountContacts', search: search)
+      def show_account_contacts(search = nil, **params)
+        params[:search] = search
+
+        get('accountContacts', params)
       end
 
       #

--- a/lib/active_campaign/api/accounts.rb
+++ b/lib/active_campaign/api/accounts.rb
@@ -36,11 +36,18 @@ module ActiveCampaign
       # Get a list of accounts
       #
       # @param [String] search Filter accounts that match the given value in the account attributes
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Array<Hash>]
       #
-      def show_accounts(search = nil)
-        get('accounts', search: search)
+      def show_accounts(search = nil, **params)
+        params[:search] = search
+
+        get('accounts', params)
       end
 
       #

--- a/lib/active_campaign/api/addresses.rb
+++ b/lib/active_campaign/api/addresses.rb
@@ -45,10 +45,16 @@ module ActiveCampaign
       #
       # Get a list of address
       #
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
+      #
       # @return [Array<Hash>]
       #
-      def show_addresses(*params)
-        get('addresses', *params)
+      def show_addresses(**params)
+        get('addresses', params)
       end
 
       #

--- a/lib/active_campaign/api/contact_tags.rb
+++ b/lib/active_campaign/api/contact_tags.rb
@@ -37,11 +37,16 @@ module ActiveCampaign
       # Retrieve contact tags for a contact
       #
       # @param [Integer] id the id of the contact to retrieve contact tags for
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Hash] a hash with the information of all contact tags of the contact
       #
-      def show_contact_contact_tags(id)
-        get("contacts/#{id}/contactTags")
+      def show_contact_contact_tags(id, **params)
+        get("contacts/#{id}/contactTags", params)
       end
 
       # NOTE: Undocumented functionality
@@ -58,10 +63,16 @@ module ActiveCampaign
       #
       # Retrieve a list of all contact tags
       #
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
+      #
       # @return [Hash] a hash with the information of all contact tags
       #
-      def show_contact_tags
-        get('contactTags')
+      def show_contact_tags(**params)
+        get('contactTags', params)
       end
     end
   end

--- a/lib/active_campaign/api/contacts.rb
+++ b/lib/active_campaign/api/contacts.rb
@@ -67,6 +67,11 @@ module ActiveCampaign
       # @option params [Integer] :seriesid Filter contacts associated with the given automation
       # @option params [Integer] :status See available values
       # @option params [Integer] :tagid Filter contacts associated with the given tag
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
+      #
       # @param [Hash] filters a list of filters
       # @option filters [Date] :created_before Filter contacts that were created prior to this date
       # @option filters [Date] :created_after Filter contacts that were created after this date

--- a/lib/active_campaign/api/deal_custom_field_data.rb
+++ b/lib/active_campaign/api/deal_custom_field_data.rb
@@ -80,11 +80,18 @@ module ActiveCampaign
       # Get a list of dealCustomDatum
       #
       # @param [String] search Filter pipelines that match the given value in the pipeline attributes
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Array<Hash>]
       #
-      def show_deal_custom_field_datas(search = nil)
-        get('dealCustomFieldData', search: search)
+      def show_deal_custom_field_datas(search = nil, **params)
+        params[:search] = search
+
+        get('dealCustomFieldData', params)
       end
 
       # rubocop:disable Layout/LineLength

--- a/lib/active_campaign/api/deal_custom_field_meta.rb
+++ b/lib/active_campaign/api/deal_custom_field_meta.rb
@@ -44,11 +44,18 @@ module ActiveCampaign
       # Get a list of dealCustomMetum
       #
       # @param [String] search Filter pipelines that match the given value in the pipeline attributes
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Array<Hash>]
       #
-      def show_deal_custom_field_metas(search = nil)
-        get('dealCustomFieldMeta', search: search)
+      def show_deal_custom_field_metas(search = nil, **params)
+        params[:search] = search
+
+        get('dealCustomFieldMeta', params)
       end
 
       # rubocop:disable Layout/LineLength

--- a/lib/active_campaign/api/deal_stages.rb
+++ b/lib/active_campaign/api/deal_stages.rb
@@ -47,10 +47,17 @@ module ActiveCampaign
       # Get a list of pipelines (dealStages)
       #
       # @param [String] search Filter pipelines that match the given value in the pipeline attributes
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Array<Hash>]
       #
-      def show_deal_stages(search = nil)
+      def show_deal_stages(search = nil, **params)
+        params[:search] = search
+
         get('dealStages', search: search)
       end
 

--- a/lib/active_campaign/api/deals.rb
+++ b/lib/active_campaign/api/deals.rb
@@ -75,11 +75,18 @@ module ActiveCampaign
       # Get a list of deals
       #
       # @param [String] search Filter deals that match the given value in the deal attributes
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Array<Hash>]
       #
-      def show_deals(search = nil)
-        get('deals', search: search)
+      def show_deals(search = nil, **params)
+        params[:search] = search
+
+        get('deals', params)
       end
 
       # rubocop:disable Layout/LineLength

--- a/lib/active_campaign/api/field_values.rb
+++ b/lib/active_campaign/api/field_values.rb
@@ -66,10 +66,16 @@ module ActiveCampaign
       # @option [Hash] filters filter the list of custom field values with this data
       # @option filter [String] :fieldid the id of the field the value belongs to
       # @option filter [String] :val the value of the custom field for a specify contact
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Hash] a hash with the information of field values that match the filters
-      def show_field_values(filters: {}, **params)
-        params[:filters] = filters if filters.any?
+      def show_field_values(filters: nil, **params)
+        params[:filters] = filters if filters
+
         get('fieldValues', params)
       end
     end

--- a/lib/active_campaign/api/fields.rb
+++ b/lib/active_campaign/api/fields.rb
@@ -79,10 +79,15 @@ module ActiveCampaign
 
       #
       # List all custom fields
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Hash] a hash with information on all custom fields
-      def show_fields
-        get('fields')
+      def show_fields(**params)
+        get('fields', params)
       end
 
       #

--- a/lib/active_campaign/api/groups.rb
+++ b/lib/active_campaign/api/groups.rb
@@ -92,11 +92,18 @@ module ActiveCampaign
       # Get a list of groups
       #
       # @param [String] search Filter groups that match the given value in the group attributes
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Array<Hash>]
       #
-      def show_groups(search = nil)
-        get('groups', search: search)
+      def show_groups(search = nil, **params)
+        params[:search] = search
+
+        get('groups', params)
       end
 
       #

--- a/lib/active_campaign/api/lists.rb
+++ b/lib/active_campaign/api/lists.rb
@@ -51,11 +51,18 @@ module ActiveCampaign
       # Get a list of lists
       #
       # @param [String] search Filter lists that match the given value in the list attributes
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Array<Hash>]
       #
-      def show_lists(search = nil)
-        get('lists', search: search)
+      def show_lists(search = nil, **params)
+        params[:search] = search
+
+        get('lists', params)
       end
 
       #

--- a/lib/active_campaign/api/pipelines.rb
+++ b/lib/active_campaign/api/pipelines.rb
@@ -45,11 +45,18 @@ module ActiveCampaign
       # Get a list of pipelines (dealGroups)
       #
       # @param [String] search Filter pipelines that match the given value in the pipeline attributes
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Array<Hash>]
       #
-      def show_pipelines(search = nil)
-        get('dealGroups', search: search)
+      def show_pipelines(search = nil, **params)
+        params[:search] = search
+
+        get('dealGroups', params)
       end
       alias show_deal_groups show_pipelines
 

--- a/lib/active_campaign/api/tags.rb
+++ b/lib/active_campaign/api/tags.rb
@@ -36,10 +36,16 @@ module ActiveCampaign
       #
       # List all tags
       #
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
+      #
       # @return [Hash] a hash the information for all tags
       #
-      def show_tags
-        get('tags')
+      def show_tags(**params)
+        get('tags', params)
       end
 
       #

--- a/lib/active_campaign/api/users.rb
+++ b/lib/active_campaign/api/users.rb
@@ -72,11 +72,16 @@ module ActiveCampaign
       # Get a user of users
       #
       # @param [String] search Filter users that match the given value in the user attributes
+      # @option [Hash] params Return results based on this data
+      # @option params [Integer] :limit The number of results to display in each page (default = 20; max = 100).
+      # @option params [Integer] :offset The starting point for the result set of a page. This is a zero-based index.
+      #   For example, if there are 39 total records and the limit is the default of 20, use offset=20 to get the second
+      #   page of results.
       #
       # @return [Array<Hash>]
       #
-      def show_users
-        get('users')
+      def show_users(**params)
+        get('users', params)
       end
 
       #

--- a/spec/cassettes/ActiveCampaign_API_AccountContacts/_show_accounts/returns_a_account_contacts_array.yml
+++ b/spec/cassettes/ActiveCampaign_API_AccountContacts/_show_accounts/returns_a_account_contacts_array.yml
@@ -534,4 +534,71 @@ http_interactions:
       string: '{"message":"No Result found for CustomerAccount with id 1"}'
     http_version: null
   recorded_at: Sun, 24 May 2020 10:16:31 GMT
+- request:
+    method: get
+    uri: "<API_ENDPOINT>/accountContacts"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ActiveCampaign Ruby Client (v3.0.0)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Api-Token:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 15 Jul 2020 06:20:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '43'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - PHPSESSID=3e560c9e60b8d3b35fb091f33322f241; path=/; HttpOnly
+      - __cfduid=dc441b2a285a3547373cb013d628595511594794006; expires=Fri, 14-Aug-20
+        06:20:06 GMT; path=/; domain=.api-us1.com; HttpOnly; SameSite=Lax
+      - em_acp_globalauth_cookie=6f379149-b358-4eb7-af0e-3788b14548d2; path=/; domain=.camplify1592887147.api-us1.com;
+        secure; httponly
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      X-Envoy-Upstream-Service-Time:
+      - '93'
+      X-Request-Id:
+      - c854141a-4c1e-4df2-b527-09d84c11f0fe
+      Accept-Ranges:
+      - bytes
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 03f2ba71a4000016ad761c2200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5b31602f6b3216ad-SYD
+    body:
+      encoding: UTF-8
+      string: '{"accountContacts":[],"meta":{"total":"0"}}'
+    http_version: null
+  recorded_at: Wed, 15 Jul 2020 06:20:07 GMT
 recorded_with: VCR 5.1.0

--- a/spec/cassettes/ActiveCampaign_API_Accounts/_show_accounts/returns_an_accounts_array.yml
+++ b/spec/cassettes/ActiveCampaign_API_Accounts/_show_accounts/returns_an_accounts_array.yml
@@ -197,4 +197,71 @@ http_interactions:
       string: "{}"
     http_version: null
   recorded_at: Sun, 24 May 2020 10:17:15 GMT
+- request:
+    method: get
+    uri: "<API_ENDPOINT>/accounts"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ActiveCampaign Ruby Client (v3.0.0)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Api-Token:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 15 Jul 2020 06:20:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '36'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - PHPSESSID=ec05ea673e93217b4f551445afc89012; path=/; HttpOnly
+      - __cfduid=d6f0d5d98aace71e22fcc5b4504839c2a1594794007; expires=Fri, 14-Aug-20
+        06:20:07 GMT; path=/; domain=.api-us1.com; HttpOnly; SameSite=Lax
+      - em_acp_globalauth_cookie=c470a223-548c-48c8-9130-b95880a35af6; path=/; domain=.camplify1592887147.api-us1.com;
+        secure; httponly
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      X-Envoy-Upstream-Service-Time:
+      - '81'
+      X-Request-Id:
+      - 4aab38ff-2a1c-448d-9ec9-ff93ca8185f8
+      Accept-Ranges:
+      - bytes
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 03f2ba73680000fe74e28d5200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5b3160324816fe74-SYD
+    body:
+      encoding: UTF-8
+      string: '{"accounts":[],"meta":{"total":"0"}}'
+    http_version: null
+  recorded_at: Wed, 15 Jul 2020 06:20:07 GMT
 recorded_with: VCR 5.1.0

--- a/spec/cassettes/ActiveCampaign_API_DealCustomFieldData/_bulk_create_deal_custom_field_data/returns_a_message_hash.yml
+++ b/spec/cassettes/ActiveCampaign_API_DealCustomFieldData/_bulk_create_deal_custom_field_data/returns_a_message_hash.yml
@@ -1010,4 +1010,71 @@ http_interactions:
       string: "{}"
     http_version: null
   recorded_at: Sun, 24 May 2020 13:18:12 GMT
+- request:
+    method: get
+    uri: "<API_ENDPOINT>/dealCustomFieldData"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ActiveCampaign Ruby Client (v3.0.0)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Api-Token:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 15 Jul 2020 06:20:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - PHPSESSID=50e5ac2962162e077d0222c064677bfb; path=/; HttpOnly
+      - __cfduid=d91aae03dd73cbea5fa944beff71e43bb1594794008; expires=Fri, 14-Aug-20
+        06:20:08 GMT; path=/; domain=.api-us1.com; HttpOnly; SameSite=Lax
+      - em_acp_globalauth_cookie=7031dcfc-b8cd-4018-9032-14533fd4768f; path=/; domain=.camplify1592887147.api-us1.com;
+        secure; httponly
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      X-Envoy-Upstream-Service-Time:
+      - '121'
+      X-Request-Id:
+      - 907bbaac-c090-441e-ba3f-1e333703035a
+      Accept-Ranges:
+      - bytes
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 03f2ba76080000fd52dc806200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5b3160367b2efd52-SYD
+    body:
+      encoding: UTF-8
+      string: '{"dealCustomFieldData":[],"meta":{"total":0}}'
+    http_version: null
+  recorded_at: Wed, 15 Jul 2020 06:20:08 GMT
 recorded_with: VCR 5.1.0

--- a/spec/cassettes/ActiveCampaign_API_DealCustomFieldData/_show_deal_custom_field_datas/returns_a_deal_custom_field_data_hash.yml
+++ b/spec/cassettes/ActiveCampaign_API_DealCustomFieldData/_show_deal_custom_field_datas/returns_a_deal_custom_field_data_hash.yml
@@ -1012,4 +1012,71 @@ http_interactions:
       string: "{}"
     http_version: null
   recorded_at: Sun, 24 May 2020 12:47:24 GMT
+- request:
+    method: get
+    uri: "<API_ENDPOINT>/dealCustomFieldData"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ActiveCampaign Ruby Client (v3.0.0)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Api-Token:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 15 Jul 2020 06:20:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - PHPSESSID=aac082e42b246b4515c56b37be46f792; path=/; HttpOnly
+      - __cfduid=dab1d8e52e0d6fc020664da6149716d0b1594794008; expires=Fri, 14-Aug-20
+        06:20:08 GMT; path=/; domain=.api-us1.com; HttpOnly; SameSite=Lax
+      - em_acp_globalauth_cookie=1894d5be-dfd0-4e96-b3a1-51e15df7f0b3; path=/; domain=.camplify1592887147.api-us1.com;
+        secure; httponly
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      X-Envoy-Upstream-Service-Time:
+      - '132'
+      X-Request-Id:
+      - 969ef50d-780f-4aac-9900-ed42c47d2ca6
+      Accept-Ranges:
+      - bytes
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 03f2ba79020000d6a1ae0e6200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5b31603b3c3cd6a1-SYD
+    body:
+      encoding: UTF-8
+      string: '{"dealCustomFieldData":[],"meta":{"total":0}}'
+    http_version: null
+  recorded_at: Wed, 15 Jul 2020 06:20:09 GMT
 recorded_with: VCR 5.1.0

--- a/spec/cassettes/ActiveCampaign_API_DealCustomFieldMeta/_show_deal_custom_field_metas/returns_a_deal_custom_field_metas_array.yml
+++ b/spec/cassettes/ActiveCampaign_API_DealCustomFieldMeta/_show_deal_custom_field_metas/returns_a_deal_custom_field_metas_array.yml
@@ -197,4 +197,69 @@ http_interactions:
       string: '{"message":"DealCustomFieldMeta deleted."}'
     http_version: null
   recorded_at: Sun, 24 May 2020 10:15:44 GMT
+- request:
+    method: get
+    uri: "<API_ENDPOINT>/dealCustomFieldMeta"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ActiveCampaign Ruby Client (v3.0.0)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Api-Token:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 15 Jul 2020 06:20:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - PHPSESSID=bb9f6acf72aab5bcd1e1fd9e295e5554; path=/; HttpOnly
+      - __cfduid=d6e6f55850ce5a094b221970c1a0265d61594794009; expires=Fri, 14-Aug-20
+        06:20:09 GMT; path=/; domain=.api-us1.com; HttpOnly; SameSite=Lax
+      - em_acp_globalauth_cookie=b62858b8-9f82-449b-b94e-65e7760f17cc; path=/; domain=.camplify1592887147.api-us1.com;
+        secure; httponly
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      X-Envoy-Upstream-Service-Time:
+      - '151'
+      X-Request-Id:
+      - dce6cb01-ff78-4cf9-8990-09926ce73707
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 03f2ba7b0a000016e1a3a44200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5b31603e792f16e1-SYD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"dealCustomFieldMeta":[{"id":"1","fieldLabel":"Forecasted Close Date","fieldType":"date","fieldOptions":null,"fieldDefault":null,"fieldDefaultCurrency":null,"isFormVisible":0,"isRequired":0,"displayOrder":-1,"personalization":"DEAL_FORECASTED_CLOSE_DATE","knownFieldId":13,"hideFieldFlag":0,"createdTimestamp":"2020-06-23T04:39:25+00:00","updatedTimestamp":"2020-06-23T04:39:25+00:00","links":{"dealCustomFieldData":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealCustomFieldMeta\/1\/dealCustomFieldData"}}]}'
+    http_version: null
+  recorded_at: Wed, 15 Jul 2020 06:20:09 GMT
 recorded_with: VCR 5.1.0

--- a/spec/cassettes/ActiveCampaign_API_Deals/_show_deals/returns_a_deal_hash.yml
+++ b/spec/cassettes/ActiveCampaign_API_Deals/_show_deals/returns_a_deal_hash.yml
@@ -751,4 +751,71 @@ http_interactions:
       string: "{}"
     http_version: null
   recorded_at: Sun, 24 May 2020 10:30:05 GMT
+- request:
+    method: get
+    uri: "<API_ENDPOINT>/deals"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ActiveCampaign Ruby Client (v3.0.0)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Api-Token:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 15 Jul 2020 06:20:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '47'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - PHPSESSID=54d2c1e4120abe5ddaf360522ff1e3ce; path=/; HttpOnly
+      - __cfduid=d6fcd83a69ccabccd344ddf09473ca8091594794010; expires=Fri, 14-Aug-20
+        06:20:10 GMT; path=/; domain=.api-us1.com; HttpOnly; SameSite=Lax
+      - em_acp_globalauth_cookie=370447be-29fb-4425-95c7-523efcc4d522; path=/; domain=.camplify1592887147.api-us1.com;
+        secure; httponly
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      X-Envoy-Upstream-Service-Time:
+      - '88'
+      X-Request-Id:
+      - 7d49595f-97ba-465e-92cb-9e225346c641
+      Accept-Ranges:
+      - bytes
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 03f2ba7e36000016b9e6bee200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5b3160438bec16b9-SYD
+    body:
+      encoding: UTF-8
+      string: '{"deals":[],"meta":{"currencies":[],"total":0}}'
+    http_version: null
+  recorded_at: Wed, 15 Jul 2020 06:20:10 GMT
 recorded_with: VCR 5.1.0

--- a/spec/cassettes/ActiveCampaign_API_Groups/_show_groups/returns_a_group_hash.yml
+++ b/spec/cassettes/ActiveCampaign_API_Groups/_show_groups/returns_a_group_hash.yml
@@ -199,4 +199,70 @@ http_interactions:
       string: "{}"
     http_version: null
   recorded_at: Sun, 24 May 2020 10:15:46 GMT
+- request:
+    method: get
+    uri: "<API_ENDPOINT>/groups"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ActiveCampaign Ruby Client (v3.0.0)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Api-Token:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 15 Jul 2020 06:20:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - PHPSESSID=22cf394b3837d1388ced89e3c4b23fc4; path=/; HttpOnly
+      - __cfduid=d4afde2d1f33ee6c5b793b4ff82b99be51594794011; expires=Fri, 14-Aug-20
+        06:20:11 GMT; path=/; domain=.api-us1.com; HttpOnly; SameSite=Lax
+      - em_acp_globalauth_cookie=bc9aa9ea-7373-46bb-a1ba-7876d96115fb; path=/; domain=.camplify1592887147.api-us1.com;
+        secure; httponly
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      X-Envoy-Upstream-Service-Time:
+      - '80'
+      X-Request-Id:
+      - 8c5da748-f8d3-4d5d-b070-aa8188504e98
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 03f2ba8203000016b9bbbfc200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5b3160499e4816b9-SYD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"groups":[{"title":"Admin","descript":"This is a group for admin users
+        (people that can manage content)","unsubscribelink":"0","optinconfirm":"0","p_admin":"1","pgListAdd":"1","pgListEdit":"1","pgListDelete":"1","pgListHeaders":"1","pgListEmailaccount":"1","pgListBounce":"1","pgMessageAdd":"1","pgMessageEdit":"1","pgMessageDelete":"1","pgMessageSend":"1","pgContactAdd":"1","pgContactEdit":"1","pgContactDelete":"1","pgContactMerge":"1","pgContactImport":"1","pgContactApprove":"1","pgContactExport":"1","pgContactSync":"1","pgContactFilters":"1","pgContactActions":"0","pgContactFields":"1","pg_user_add":"1","pg_user_edit":"1","pg_user_delete":"1","pgGroupAdd":"1","pgGroupEdit":"1","pgGroupDelete":"1","pgTemplateAdd":"1","pgTemplateEdit":"1","pgTemplateDelete":"1","pgPersonalizationAdd":"1","pgPersonalizationEdit":"1","pgPersonalizationDelete":"1","pgAutomationManage":"1","pgFormEdit":"1","pgReportsCampaign":"1","pgReportsList":"1","pgReportsUser":"1","pgReportsTrend":"1","pgReportsDeal":"1","pgStartupReports":"1","pgStartupGettingstarted":"1","pgAccountAdd":"1","pgAccountEdit":"1","pgAccountDelete":"1","pgAccountManageCustomField":"1","pgDeal":"1","pgDealDelete":"1","pgDealReassign":"1","pgDealFields":"1","pgDealGroupAdd":"1","pgDealGroupEdit":"1","pgDealGroupDelete":"1","pgSavedResponsesManage":"1","sdate":"2020-06-22T23:39:25-05:00","reqApproval":"0","reqApproval1st":"2","reqApprovalNotify":"","socialdata":"0","pgMfaAdmin":"1","pgDealExport":"1","pgDealManageRoles":"1","pgAccountNoteAdd":"0","pgAccountNoteEdit":"0","pgAccountNoteDelete":"0","pgDealNoteAdd":"0","pgDealNoteEdit":"0","pgDealNoteDelete":"0","pgDealListAll":"1","pgTagManage":"1","pgContactResubscribe":"1","pgDealImport":"1","pgAccountImport":"1","pgAccountExport":"1","links":{"userGroups":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/groups\/3\/userGroups","groupLimit":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/groups\/3\/groupLimit","dealGroupGroups":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/groups\/3\/dealGroupGroups","listGroups":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/groups\/3\/listGroups","addressGroups":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/groups\/3\/addressGroups","automationGroups":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/groups\/3\/automationGroups"},"id":"3"}],"meta":{"total":"1"}}'
+    http_version: null
+  recorded_at: Wed, 15 Jul 2020 06:20:11 GMT
 recorded_with: VCR 5.1.0

--- a/spec/cassettes/ActiveCampaign_API_Lists/_show_lists/returns_a_lists_array.yml
+++ b/spec/cassettes/ActiveCampaign_API_Lists/_show_lists/returns_a_lists_array.yml
@@ -199,4 +199,71 @@ http_interactions:
       string: "{}"
     http_version: null
   recorded_at: Sun, 24 May 2020 10:17:12 GMT
+- request:
+    method: get
+    uri: "<API_ENDPOINT>/lists"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ActiveCampaign Ruby Client (v3.0.0)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Api-Token:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 15 Jul 2020 06:20:11 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '33'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - PHPSESSID=617f4182f0f979f220283b413b1e7274; path=/; HttpOnly
+      - __cfduid=d41637ce0e78ff828d34951e723ae933f1594794011; expires=Fri, 14-Aug-20
+        06:20:11 GMT; path=/; domain=.api-us1.com; HttpOnly; SameSite=Lax
+      - em_acp_globalauth_cookie=a823670d-946f-47c3-83d1-5acc90b8322d; path=/; domain=.camplify1592887147.api-us1.com;
+        secure; httponly
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      X-Envoy-Upstream-Service-Time:
+      - '80'
+      X-Request-Id:
+      - 7da1d05e-b5f2-4aa7-b712-a120de848a9b
+      Accept-Ranges:
+      - bytes
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 03f2ba83890000da462f8f9200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5b31604c0a4ada46-SYD
+    body:
+      encoding: UTF-8
+      string: '{"lists":[],"meta":{"total":"0"}}'
+    http_version: null
+  recorded_at: Wed, 15 Jul 2020 06:20:11 GMT
 recorded_with: VCR 5.1.0

--- a/spec/cassettes/ActiveCampaign_API_Pipelines/_show_pipelines/returns_a_pipelines_array.yml
+++ b/spec/cassettes/ActiveCampaign_API_Pipelines/_show_pipelines/returns_a_pipelines_array.yml
@@ -479,4 +479,92 @@ http_interactions:
       string: "{}"
     http_version: null
   recorded_at: Sun, 24 May 2020 10:15:30 GMT
+- request:
+    method: get
+    uri: "<API_ENDPOINT>/dealGroups"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ActiveCampaign Ruby Client (v3.0.0)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Api-Token:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 15 Jul 2020 06:20:12 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - PHPSESSID=490489ed233e2df595118510b7b03bd0; path=/; HttpOnly
+      - __cfduid=d7df15e6469e9b41f338fb836b9b2fbfe1594794012; expires=Fri, 14-Aug-20
+        06:20:12 GMT; path=/; domain=.api-us1.com; HttpOnly; SameSite=Lax
+      - em_acp_globalauth_cookie=024f6789-0592-4cd2-b4a9-72b422449a43; path=/; domain=.camplify1592887147.api-us1.com;
+        secure; httponly
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      - em_acp_globalauth_cookie=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT; Max-Age=0;
+        path=/; domain=.camplify1592887147.api-us1.com
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      X-Envoy-Upstream-Service-Time:
+      - '121'
+      X-Request-Id:
+      - d0142dfd-5608-40df-a9a1-b5a344eba0d8
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 03f2ba8576000016bd92028200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5b31604f28c416bd-SYD
+    body:
+      encoding: ASCII-8BIT
+      string: '{"dealStages":[{"group":"17","title":"To Contact","color":"19CCA3","order":"1","width":"280","dealOrder":"next-action
+        DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/53\/group"},"id":"53"},{"group":"17","title":"In
+        Contact","color":"5884EA","order":"2","width":"280","dealOrder":"next-action
+        DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/54\/group"},"id":"54"},{"group":"17","title":"Follow
+        Up","color":"FBD965","order":"3","width":"280","dealOrder":"next-action DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/55\/group"},"id":"55"},{"group":"37","title":"To
+        Contact","color":"19CCA3","order":"1","width":"280","dealOrder":"next-action
+        DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/117\/group"},"id":"117"},{"group":"37","title":"In
+        Contact","color":"5884EA","order":"2","width":"280","dealOrder":"next-action
+        DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/118\/group"},"id":"118"},{"group":"37","title":"Follow
+        Up","color":"FBD965","order":"3","width":"280","dealOrder":"next-action DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/119\/group"},"id":"119"},{"group":"57","title":"To
+        Contact","color":"19CCA3","order":"1","width":"280","dealOrder":"next-action
+        DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/181\/group"},"id":"181"},{"group":"57","title":"In
+        Contact","color":"5884EA","order":"2","width":"280","dealOrder":"next-action
+        DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/182\/group"},"id":"182"},{"group":"57","title":"Follow
+        Up","color":"FBD965","order":"3","width":"280","dealOrder":"next-action DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/183\/group"},"id":"183"},{"group":"93","title":"To
+        Contact","color":"19CCA3","order":"1","width":"280","dealOrder":"next-action
+        DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/297\/group"},"id":"297"},{"group":"93","title":"In
+        Contact","color":"5884EA","order":"2","width":"280","dealOrder":"next-action
+        DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/298\/group"},"id":"298"},{"group":"93","title":"Follow
+        Up","color":"FBD965","order":"3","width":"280","dealOrder":"next-action DESC","cardRegion1":"title","cardRegion2":"next-action","cardRegion3":"show-avatar","cardRegion4":"contact-fullname-acctname","cardRegion5":"value","cdate":null,"udate":null,"links":{"group":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealStages\/299\/group"},"id":"299"}],"dealGroups":[{"title":"Bogus
+        Pipeline","currency":"eur","autoassign":"1","allusers":"1","allgroups":"1","win_probability_initialize_date":null,"cdate":"2020-07-14T23:19:27-05:00","udate":"2020-07-14T23:19:27-05:00","stages":["53","54","55"],"links":{"stages":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/17\/stages","dealGroupUsers":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/17\/dealGroupUsers","dealGroupGroups":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/17\/dealGroupGroups","winProbabilityFeatures":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/17\/winProbabilityFeatures"},"id":"17"},{"title":"Bogus
+        Pipeline","currency":"eur","autoassign":"1","allusers":"1","allgroups":"1","win_probability_initialize_date":null,"cdate":"2020-07-14T23:26:49-05:00","udate":"2020-07-14T23:26:49-05:00","stages":["117","118","119"],"links":{"stages":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/37\/stages","dealGroupUsers":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/37\/dealGroupUsers","dealGroupGroups":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/37\/dealGroupGroups","winProbabilityFeatures":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/37\/winProbabilityFeatures"},"id":"37"},{"title":"Bogus
+        Pipeline","currency":"eur","autoassign":"1","allusers":"1","allgroups":"1","win_probability_initialize_date":null,"cdate":"2020-07-14T23:32:14-05:00","udate":"2020-07-14T23:32:14-05:00","stages":["181","182","183"],"links":{"stages":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/57\/stages","dealGroupUsers":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/57\/dealGroupUsers","dealGroupGroups":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/57\/dealGroupGroups","winProbabilityFeatures":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/57\/winProbabilityFeatures"},"id":"57"},{"title":"Bogus
+        Pipeline","currency":"eur","autoassign":"1","allusers":"1","allgroups":"1","win_probability_initialize_date":null,"cdate":"2020-07-14T23:59:56-05:00","udate":"2020-07-14T23:59:56-05:00","stages":["297","298","299"],"links":{"stages":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/93\/stages","dealGroupUsers":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/93\/dealGroupUsers","dealGroupGroups":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/93\/dealGroupGroups","winProbabilityFeatures":"https:\/\/camplify1592887147.api-us1.com\/api\/3\/dealGroups\/93\/winProbabilityFeatures"},"id":"93"}],"meta":{"total":"4"}}'
+    http_version: null
+  recorded_at: Wed, 15 Jul 2020 06:20:12 GMT
 recorded_with: VCR 5.1.0


### PR DESCRIPTION
Hi,

I realised I needed to be able to use the 'limit' and 'offset' pagination parameters for collections, otherwise I was only able to pull down the first 20 of any particular thing (specifically I needed to be able to access more than 20 custom fields).

I've added double-splat params to all the collection endpoint methods so that they can be supplied, as can anything else, rather than adding an explicit and specific arguments for them.

Let me know if you prefer another approach.

Also, I haven't written any tests for 'limit' and 'offset' (well, I did, but only for one endpoint, and it was hacky, so I figured I'd be better off getting feedback before spending the time on writing them for more endpoints). Let me know if you have any suggestions/preferences for tests. Do the pagination parameters need to be tested for every one of the collection endpoints? Also, do we need to test large numbers of items, or is 2 sufficient, do you think? Currently there's no easy way to generate an arbitrary number of different users set up. I see factory_bot is in there, but not set up for Contacts at least (in my hacky test, I just inserted counter into the email address to create 50 Contacts).