### PR TITLE
Fallback to default `Configuration` in `Client.new`

### DIFF
--- a/lib/active_campaign/client.rb
+++ b/lib/active_campaign/client.rb
@@ -30,7 +30,7 @@ module ActiveCampaign
     attr_reader :config
 
     def initialize(conf = {})
-      @config = conf
+      @config = Configuration.new.to_h.merge(conf)
     end
 
     def connection # rubocop:disable Metrics/AbcSize

--- a/spec/cassettes/ActiveCampaign_Client/_new/can_be_used_to_intialize_a_client_object_that_can_make_requests.yml
+++ b/spec/cassettes/ActiveCampaign_Client/_new/can_be_used_to_intialize_a_client_object_that_can_make_requests.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://fake.com/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ActiveCampaign Ruby Client (v3.0.0)
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Mon, 07 Sep 2020 18:21:12 GMT
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - max-age=3600
+      Expires:
+      - Mon, 07 Sep 2020 19:21:12 GMT
+      Location:
+      - https://fake.com/
+      Cf-Request-Id:
+      - 050b66066a0000fec293a40200000001
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 5cf272b71f2bfec2-IAH
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 07 Sep 2020 18:21:12 GMT
+recorded_with: VCR 6.0.0

--- a/spec/lib/active_campaign/client_spec.rb
+++ b/spec/lib/active_campaign/client_spec.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.describe ActiveCampaign::Client, :vcr do
+RSpec.describe ActiveCampaign::Client do
   describe '.new' do
     it 'can be used to intialize a client object that can make requests' do
-      WebMock.stub_request(:get, 'http://fake.com/').with(body: '{}')
+      stub = WebMock.stub_request(:get, 'http://fake.com/').to_return(body: '{}')
+
       described_class.new.get('http://fake.com/')
+
+      expect(stub).to have_been_requested
     end
   end
 end

--- a/spec/lib/active_campaign/client_spec.rb
+++ b/spec/lib/active_campaign/client_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe ActiveCampaign::Client, :vcr do
   describe '.new' do
     it 'can be used to intialize a client object that can make requests' do
-      WebMock.stub_request(:get, "http://fake.com/").with(body: "{}")
-      described_class.new.get("http://fake.com/")
+      WebMock.stub_request(:get, 'http://fake.com/').with(body: '{}')
+      described_class.new.get('http://fake.com/')
     end
   end
 end

--- a/spec/lib/active_campaign/client_spec.rb
+++ b/spec/lib/active_campaign/client_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe ActiveCampaign::Client, :vcr do
+  describe '.new' do
+    it 'can be used to intialize a client object that can make requests' do
+      WebMock.stub_request(:get, "http://fake.com/").with(body: "{}")
+      described_class.new.get("http://fake.com/")
+    end
+  end
+end


### PR DESCRIPTION
Use `Configuration` to provide default option when using `Client.new` in
order to avoid `nil` errors that would occur when using `Client.new`
directly without the user specifying the `:adapter` and
`:response_middleware` options.

Fix #74