### PR TITLE
adds warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 [![Build Status](https://travis-ci.org/mhenrixon/active_campaign.svg?branch=master)](https://travis-ci.org/mhenrixon/active_campaign)[![Code Climate](https://codeclimate.com/github/mhenrixon/active_campaign/badges/gpa.svg)](https://codeclimate.com/github/mhenrixon/active_campaign)[![Test Coverage](https://codeclimate.com/github/mhenrixon/active_campaign/badges/coverage.svg)](https://codeclimate.com/github/mhenrixon/active_campaign/coverage)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmhenrixon%2Factive_campaign.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fmhenrixon%2Factive_campaign?ref=badge_shield)
+# WARNING
+
+The master branch has documentation and an API that is not consistent with the version published on RubyGems.
+
+For the latest Rubygems published version, please see https://github.com/mhenrixon/active_campaign/tree/v0.1.16
+
 # Active::Campaign::Ruby
 
 A simple wrapper for the ActiveCampaign API. Since their API seems to be


### PR DESCRIPTION
**Note that even the README on 0.1.16 is confusing now, because the subdomain given to you does not work without adding `/admin/api.php` to the end of it**

here, I've configured it globally using an all-caps global variable as the object is supposed to exist as a singleton. 

```
ACTIVE_CAMPAIGN_CLIENT = ::ActiveCampaign::Client.new(
        api_endpoint: 'https://[YOUR ACTIVE CAMPAIGN DOMAIN]/admin/api.php', # e.g. 'https://yourendpoint.api-us1.com/admin/api.php'
        api_key: '[YOUR-API-KEY]') # e.g. 'a4e60a1ba200595d5cc37ede5732545184165e'
```

the gem works fine but the documentation is head-spinningly confusing, so much so that the barrier to entry for using this gem is unnecessarily high. 