### PR TITLE
Add Ruby 3.0 and 3.1 to CI, Split out Faraday 1 and 2

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -4,15 +4,20 @@ jobs:
   tests:
     env:
       COV: true
+      BUNDLE_GEMFILE: "gemfiles/faraday_${{ matrix.faraday_version }}.gemfile"
 
     runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby }} on Faraday ${{ matrix.faraday_version }}
 
     strategy:
       fail-fast: true
       matrix:
         # ruby: [2.5, 2.6, 2.7, jruby, truffleruby]
-        ruby: [2.5, 2.6, 2.7]
-
+        ruby: [2.5, 2.6, 2.7, "3.0", 3.1]
+        faraday_version: [1, 2]
+        exclude:
+          - ruby: 2.5
+            faraday_version: 2
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .config
 .yardoc
 Gemfile.lock
+gemfiles/*.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,13 @@ inherit_gem:
     - config/default.yml
 
 AllCops:
-  TargetRubyVersion: 2.5'
+  TargetRubyVersion: 2.5
   Exclude:
     - 'gemfiles/**/*'
     - '**/*.json'
+
+Naming/VariableNumber:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/active_campaign.gemspec
+++ b/active_campaign.gemspec
@@ -14,14 +14,17 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/mhenrixon/active_campaign'
   spec.license       = 'MIT'
 
+  spec.required_ruby_version = '>= 2.5'
+
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = 'https://rubygems.org'
     spec.metadata['homepage_uri'] = spec.homepage
     spec.metadata['source_code_uri'] = 'https://github.com/mhenrixon/rubocop-mhenrixon'
     spec.metadata['changelog_uri'] = 'https://github.com/mhenrixon/rubocop-mhenrixon'
+    spec.metadata['rubygems_mfa_required'] = 'true'
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \
-      'public gem pushes.'
+          'public gem pushes.'
   end
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
@@ -32,4 +35,16 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport',  '>= 4.0', '< 8.0'
   spec.add_dependency 'faraday',        '>= 1.0', '< 3.0'
   spec.add_dependency 'oj',             '>= 3.0', '< 4.0'
+
+  spec.add_development_dependency 'factory_bot', '~> 6'
+  spec.add_development_dependency 'pry', '~> 0.14'
+  spec.add_development_dependency 'rake', '~> 13'
+  spec.add_development_dependency 'reek', '~> 6'
+  spec.add_development_dependency 'rspec', '~> 3.11'
+  spec.add_development_dependency 'rspec-json_expectations', '~> 2.2'
+  spec.add_development_dependency 'rubocop-mhenrixon', '~> 1'
+  spec.add_development_dependency 'simplecov', '~> 0.21'
+  spec.add_development_dependency 'simplecov-material', '~> 1'
+  spec.add_development_dependency 'vcr', '~> 6'
+  spec.add_development_dependency 'webmock', '~> 3'
 end

--- a/bin/bundle
+++ b/bin/bundle
@@ -29,7 +29,7 @@ m = Module.new do
     update_index = nil
     ARGV.each_with_index do |a, i|
       bundler_version = a if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
-      next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
+      next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/o
 
       bundler_version = Regexp.last_match(1)
       update_index = i
@@ -57,7 +57,7 @@ m = Module.new do
     return unless File.file?(lockfile)
 
     lockfile_contents = File.read(lockfile)
-    return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+    return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/o
 
     Regexp.last_match(1)
   end
@@ -88,7 +88,7 @@ m = Module.new do
     activate_bundler
   end
 
-  def activate_bundler # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def activate_bundler # rubocop:disable Metrics/MethodLength
     gem_error = activation_error_handling do
       gem 'bundler', bundler_requirement
     end
@@ -102,8 +102,8 @@ m = Module.new do
     end
 
     warn "Activating bundler (#{bundler_requirement})" \
-      " failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires," \
-      " run `gem install bundler -v '#{bundler_requirement}'`"
+         " failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires," \
+         " run `gem install bundler -v '#{bundler_requirement}'`"
     exit 42
   end
 

--- a/gemfiles/faraday_1.gemfile
+++ b/gemfiles/faraday_1.gemfile
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-gemspec
+
+gemspec path: '../'
 
 gem 'codeclimate-test-reporter'
+gem 'faraday', '~> 1'
 gem 'gem-release'
 
 platform :mri do

--- a/gemfiles/faraday_2.gemfile
+++ b/gemfiles/faraday_2.gemfile
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-gemspec
+
+gemspec path: '../'
 
 gem 'codeclimate-test-reporter'
+gem 'faraday', '~> 2'
 gem 'gem-release'
 
 platform :mri do

--- a/lib/active_campaign.rb
+++ b/lib/active_campaign.rb
@@ -77,6 +77,8 @@ module ActiveCampaign
     yield config if block_given?
   end
 
+  # rubocop:disable Lint/MissingSuper
+
   # @private
   def respond_to_missing?(method_name, include_private = false)
     client.respond_to?(method_name, include_private)
@@ -106,4 +108,6 @@ module ActiveCampaign
       client.respond_to?(method_name, include_private)
     end
   end
+
+  # rubocop:enable Lint/MissingSuper
 end

--- a/lib/active_campaign/api.rb
+++ b/lib/active_campaign/api.rb
@@ -45,6 +45,8 @@ module ActiveCampaign
         raise DependencyMissing, endpoint
       end
 
+      # rubocop:disable ThreadSafety/InstanceVariableInClassMethod
+
       #
       # Memoized logger for convenience
       #
@@ -54,6 +56,8 @@ module ActiveCampaign
       def logger
         @logger ||= ActiveCampaign.logger
       end
+
+      # rubocop:enable ThreadSafety/InstanceVariableInClassMethod
     end
   end
 end

--- a/lib/active_campaign/api/contacts.rb
+++ b/lib/active_campaign/api/contacts.rb
@@ -53,7 +53,8 @@ module ActiveCampaign
       # Get a list of contacts
       #
       # @param [Hash] params
-      # @option params param [String] :ids Filter contacts by ID. Can be repeated for multiple IDs. Example: ids: [42, 43, 1]
+      # @option params param [String] :ids Filter contacts by ID. Can be repeated for multiple IDs.
+      #   Example: ids: [42, 43, 1]
       # @option params [Date] :datetime Contacts created on the specified date
       # @option params [String] :email Email address of the contact you want to get
       # @option params [String] :email_like Filter contacts that contain the given value in the email address

--- a/lib/active_campaign/client.rb
+++ b/lib/active_campaign/client.rb
@@ -100,8 +100,6 @@ module ActiveCampaign
       raise ProxyAuthError, e
     rescue ::Faraday::ConflictError => e
       raise ConflictError, e
-    rescue ::Faraday::UnauthorizedError => e
-      raise UnauthorizedError, e
     rescue ::Faraday::UnprocessableEntityError => e
       raise UnprocessableEntityError, e
     rescue ::Faraday::ServerError => e
@@ -110,8 +108,6 @@ module ActiveCampaign
       raise TimeoutError, e
     rescue ::Faraday::NilStatusError => e
       raise NilStatusError, e
-    rescue ::Faraday::ConnectionFailed => e
-      raise ConnectionFailed, e
     rescue ::Faraday::SSLError => e
       raise SSLError, e
     end

--- a/lib/active_campaign/configuration.rb
+++ b/lib/active_campaign/configuration.rb
@@ -55,7 +55,7 @@ module ActiveCampaign
       self.api_timeout     = 5
       self.api_token       = API_TOKEN
       self.debug           = false
-      self.logger          = Logger.new(STDOUT)
+      self.logger          = Logger.new($stdout)
       @request_middleware  = {}
       @response_middleware = {}
     end

--- a/lib/active_campaign/errors.rb
+++ b/lib/active_campaign/errors.rb
@@ -22,6 +22,7 @@ module ActiveCampaign
     def initialize(response = nil, exception = nil)
       self.response = response
       @exception    = exception
+      super
     end
 
     def message
@@ -56,6 +57,7 @@ module ActiveCampaign
   class ErrorProxy < RuntimeError
     def initialize(error = nil)
       self.error = error
+      super
     end
 
     def message

--- a/lib/active_campaign/faraday/middleware/request.rb
+++ b/lib/active_campaign/faraday/middleware/request.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'faraday'
+require 'oj'
+
 module ActiveCampaign
   module Faraday
     module Middleware
@@ -9,7 +12,7 @@ module ActiveCampaign
       # @author Mikael Henriksson <mikael@mhenrixon.com>
       #
       class Request < ::Faraday::Middleware
-        dependency 'oj'
+        dependency 'oj' if respond_to?(:dependency)
 
         include TransformHash
 
@@ -45,7 +48,7 @@ module ActiveCampaign
         end
 
         def logger
-          @logger ||= Logger.new(STDOUT)
+          @logger ||= Logger.new($stdout)
         end
       end
     end

--- a/lib/active_campaign/faraday/middleware/response.rb
+++ b/lib/active_campaign/faraday/middleware/response.rb
@@ -2,9 +2,10 @@
 
 require 'logger'
 require 'faraday/logging/formatter'
+require 'oj'
 
 module ActiveCampaign
-  LOGGER = ::Logger.new(STDOUT)
+  LOGGER = ::Logger.new($stdout)
   module Faraday
     module Middleware
       #
@@ -12,8 +13,8 @@ module ActiveCampaign
       #
       # @author Mikael Henriksson <mikael@mhenrixon.com>
       #
-      class Response < ::Faraday::Response::Middleware
-        dependency 'oj'
+      class Response < ::Faraday::Middleware
+        dependency 'oj' if respond_to?(:dependency)
 
         include TransformHash
 

--- a/lib/active_campaign/transform_hash.rb
+++ b/lib/active_campaign/transform_hash.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/core_ext/string'
 
 module ActiveCampaign

--- a/spec/support/shared_contexts/with_deal.rb
+++ b/spec/support/shared_contexts/with_deal.rb
@@ -13,7 +13,7 @@ RSpec.shared_context 'with deal params', :with_deal_params do
   let(:deal_value)       { 156.24 }
   let(:deal_currency)    { 'eur' }
   let(:deal_group)       { pipeline_id }
-  let(:deal_stage)       {}
+  let(:deal_stage)       { nil }
   let(:deal_owner)       { user_id }
   let(:deal_percent)     { 50 }
   let(:deal_status)      { 0 }


### PR DESCRIPTION
This PR adds Ruby 3.0 and 3.1 to the CI matrix and adds a new row for Faraday major version (given the recent release of Faraday 2 and the middleware specific changes)

To support this goal this PR also:

1. Addresses a few lints raised by Rubocop
2. Moves a number of development dependencies from the Gemfile to the gemspec
3. Adds dedicated Faraday 1 and Faraday 2 gemfiles
4. Sets a minimum Ruby version of 2.5
5. Fixes an ActiveSupport loading issue for recent versions of ActiveSupport