### PR TITLE
no transform_keys for bulk import contacts

### DIFF
--- a/lib/active_campaign/faraday/middleware/request.rb
+++ b/lib/active_campaign/faraday/middleware/request.rb
@@ -37,6 +37,8 @@ module ActiveCampaign
             logger.debug("Using body as is because group #{body}")
           elsif body.key?(:list)
             logger.debug("Using body as is because list #{body}")
+          elsif body.key?(:contacts) && body.key?(:callback)
+            logger.debug("Using body as is because contacts+callback #{body}")
           else
             body = transform_keys(body, :camelcase, :lower)
           end


### PR DESCRIPTION
bulk import requests use snake_case keys, not camelCase, unlike most of the rest of the API.


`client.post('import/bulk_import', data)`
data should *not* have all its keys mapped to camelCase, this API will simply ignore e.g `firstName`, `lastName`.

This API call, uniquely, uses the keys `contacts` and `callback`.  Detecting these keys, the `normalize_body ` method now leaves the body alone, as it does in select other cases.

